### PR TITLE
set allowsInlineMediaPlayback to true by default

### DIFF
--- a/src/react-native-sdk.js
+++ b/src/react-native-sdk.js
@@ -72,6 +72,7 @@ function ReactNativeSdk({ queryParams, onTransakEventHandler, ...webviewProps })
 
   return (
     <WebView
+      allowsInlineMediaPlayback={true}
       {...webviewProps}
       source={{ uri: transakUrl }}
       enableApplePay


### PR DESCRIPTION
When do the selfie step, we might replicated the issue that native camera showing up on top of the webview camera. This is related to [this issue](https://github.com/react-native-webview/react-native-webview/issues/1672#issuecomment-776531933).
User can actually set that field to true to prevent the issue. But I think it is better to handle it first from SDK side.