### PR TITLE
Implement InAppBrowser for open-banking

### DIFF
--- a/src/TransakWebView.tsx
+++ b/src/TransakWebView.tsx
@@ -50,6 +50,40 @@ const TransakWebView = forwardRef<WebView, TransakWebViewInputs>(({ transakConfi
     }
   };
 
+  const openOpenBankingUrl = async (url: string) => {
+    try {
+      if (await InAppBrowser.isAvailable()) {
+        await InAppBrowser.open(url, {
+          // Android Properties
+          showTitle: false,
+          toolbarColor: transakConfig.themeColor ? `#${transakConfig.themeColor}` : '#2575fc',
+          secondaryToolbarColor: '#ffffff',
+          enableUrlBarHiding: true,
+          enableDefaultShare: false,
+          forceCloseOnRedirection: false,
+          hasBackButton: false,
+          showInRecents: false,
+          // iOS Properties
+          dismissButtonStyle: 'done',
+          preferredBarTintColor: transakConfig.themeColor ? `#${transakConfig.themeColor}` : '#2575fc',
+          preferredControlTintColor: '#ffffff',
+          readerMode: false,
+          animated: true,
+          modalPresentationStyle: 'fullScreen',
+          modalTransitionStyle: 'coverVertical',
+          modalEnabled: true,
+          enableBarCollapsing: false,
+        });
+      } else {
+        await Linking.openURL(url);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        Alert.alert(error.message);
+      }
+    }
+  };
+
   const onMessageHandler = (event: WebViewMessageEvent) => {
     if (webviewProps.onMessage) {
       webviewProps.onMessage(event);
@@ -60,6 +94,11 @@ const TransakWebView = forwardRef<WebView, TransakWebViewInputs>(({ transakConfi
     if (url.includes('/googlepay')) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       openGooglePayUrl(url.replace('isWebView', 'useAsExternalPayment'));
+    }
+
+    if (url.includes('/open-banking')) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      openOpenBankingUrl(url.replace('isWebView', 'useAsExternalPayment'));
     }
   };
 


### PR DESCRIPTION
In `src/TransakWebView.tsx`:

*   A new function, `openOpenBankingUrl`, was introduced.
    *   This function mirrors the existing `openGooglePayUrl` by utilizing `InAppBrowser` to open URLs.
    *   It configures the In-App Browser with specific properties, including theme color from `transakConfig.themeColor`, and platform-specific settings for Android and iOS.
    *   A fallback to `Linking.openURL` is included if `InAppBrowser` is unavailable, along with basic error handling.

*   The `onMessageHandler` function was updated.
    *   A new condition was added to detect URLs containing the string `/open-banking`.
    *   When such a URL is detected, the substring `isWebView` is replaced with `useAsExternalPayment`.
    *   The modified URL is then passed to the newly created `openOpenBankingUrl` function.

These changes ensure that URLs for `/open-banking` are handled consistently with `/googlepay` by opening them in an In-App Browser, providing a uniform user experience for external payment flows.